### PR TITLE
Add lint rule rejecting directional SubTree ports

### DIFF
--- a/validate_objectives.py
+++ b/validate_objectives.py
@@ -34,6 +34,17 @@ def validate_objective(xml_file: str) -> Optional[str]:
             assert (
                 metadata_fields.find(".//Metadata[@description]") is not None
             ), "Objective description not found"
+            # SubTree ports are always bidirectional, so the editor shows them as
+            # in/out. A directional <input_port>/<output_port> is hand-jammed
+            # metadata that misleads; require <inout_port> instead.
+            directional_ports = subtree_definition.findall(
+                "input_port"
+            ) + subtree_definition.findall("output_port")
+            assert not directional_ports, (
+                "SubTree ports are always bidirectional; use <inout_port> instead of "
+                "<input_port>/<output_port> for: "
+                + ", ".join(p.get("name", "<unnamed>") for p in directional_ports)
+            )
     except (ET.ParseError, AssertionError) as e:
         return f"Error validating {xml_file}: {str(e)}"
 


### PR DESCRIPTION
## Problem

SubTree ports are always bidirectional, but nothing stops an objective from declaring its SubTree interface with `<input_port>`/`<output_port>`. That mis-authored direction is invisible in the editor (the REST converter normalizes on read) yet leaks through the legacy XML endpoint, and it silently reappears in new objectives.

## Approach

In `validate_objective`, fail when a SubTree definition declares any `<input_port>`/`<output_port>` child, naming the offending ports so the author knows what to change. Uses `findall` on the SubTree element directly, so only the interface declaration is checked — not behavior ports elsewhere.

## Sequencing

Must merge **after** the `example_ws` migration (PickNikRobotics/moveit_pro#19906 → moveit_pro_example_ws#728). Enabling it earlier red-CIs the 41 existing official objectives.

## Verification

Ran the rule against `moveit_pro_example_ws` `v9.4`:
- Pre-migration content: flags exactly the 41 objectives.
- Post-migration content: flags 0.

Refs PickNikRobotics/moveit_pro#19906